### PR TITLE
:gear: forward port 3000

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
-	// "forwardPorts": [3000, 5432],
+	"forwardPorts": [3000],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "bundle install && rake db:setup",


### PR DESCRIPTION
このport forwardは vscode <-> container群の間を繋ぐようだ。
hostの指定はできないが、たとえば5432を追加するとpostgresqlのコンテナに繋がるようになる。

macとは別のLinuxマシンでdockerを動かしそこにRemote - SSHでアクセスするような構成にしているが、そのLinuxマシン上では http://localhost:3000 にアクセスできなかった。
↓ Listenしていない。
```
% docker ps
CONTAINER ID   IMAGE                                                                      COMMAND                  CREATED       STATUS          PORTS      NAMES
02c062f33d61   vsc-rails-openapi-template-a569d9a88576c052bf8916bf57dda60b-features-uid   "/bin/sh -c 'echo Co…"   2 weeks ago   Up 39 minutes              rails-openapi-template_devcontainer_app_1
f71e78e22c53   postgres:latest                                                            "docker-entrypoint.s…"   2 weeks ago   Up 46 minutes   5432/tcp   rails-openapi-template_devcontainer_db_1
%
```